### PR TITLE
Add emote size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This project uses [Go](https://go.dev) as a programming language, so you need to
 install it first.
 
 1. Clone the repository.
-2. Install its dependencies.
-3. Execute `go run main.go`
+2. Install its dependencies (`go mod download`).
+3. Execute `go run ./cmd/cli/main.go`.
 
 ## Creator
 

--- a/internal/init/command/commands.go
+++ b/internal/init/command/commands.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/guergeiro/twitch-emotes-downloader/internal/http"
 	"github.com/guergeiro/twitch-emotes-downloader/internal/mapper"
 	"github.com/guergeiro/twitch-emotes-downloader/pkg/adapter/controller"
@@ -22,22 +24,37 @@ func CreateCommand() *cobra.Command {
 
 	url := "https://www.twitchmetrics.net/emotes"
 	output := "output.zip"
+	size := "3.0"
 
 	rootCmd := &cobra.Command{
 		Use:   "twe-dl {...urls}",
 		Short: "Download twitch emotes in bulk",
 		Long: `(tw)itch (e)motes (d)own(l)oader is a cli that downloads emotes in bulk
                                    from https://www.twitchmetrics.net/`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				args = append(args, url)
 			}
 
-			c.Handle(args, output)
+			if err := validateEmoteSize(size); err != nil {
+				return err
+			}
+
+			return c.Handle(args, output, size)
 		},
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "O", "output.zip", "Output filename of zip.")
+	rootCmd.PersistentFlags().StringVarP(&size, "size", "s", "3.0", "Emote size to download: 1.0 (28px), 2.0 (56px), or 3.0 (112px).")
 
 	return rootCmd
+}
+
+func validateEmoteSize(size string) error {
+	switch size {
+	case "1.0", "2.0", "3.0":
+		return nil
+	default:
+		return fmt.Errorf("invalid size %q: expected one of 1.0, 2.0, or 3.0", size)
+	}
 }

--- a/internal/mapper/goquery.go
+++ b/internal/mapper/goquery.go
@@ -15,13 +15,14 @@ func NewGoQueryHtmlEmoteMapper() GoQueryHtmlEmoteMapper {
 	return GoQueryHtmlEmoteMapper{}
 }
 
-func (m GoQueryHtmlEmoteMapper) ToEmotes(html io.ReadCloser) ([]entity.Emote, error) {
+func (m GoQueryHtmlEmoteMapper) ToEmotes(html io.ReadCloser, size string) ([]entity.Emote, error) {
 	emotes := []entity.Emote{}
 	doc, err := goquery.NewDocumentFromReader(html)
 	if err != nil {
 		return emotes, err
 	}
 
+	normalizedSize := normalizeEmoteSize(size)
 	selection := doc.Find("samp")
 	for i := range selection.Nodes {
 		single := selection.Eq(i)
@@ -34,8 +35,34 @@ func (m GoQueryHtmlEmoteMapper) ToEmotes(html io.ReadCloser) ([]entity.Emote, er
 		if err != nil {
 			continue
 		}
+		u.Path = updateEmoteSize(u.Path, normalizedSize)
 		emotes = append(emotes, entity.NewEmote(single.Text(), *u))
 	}
 
 	return emotes, nil
+}
+
+func normalizeEmoteSize(size string) string {
+	switch strings.TrimSpace(size) {
+	case "1.0", "2.0", "3.0":
+		return size
+	default:
+		return "3.0"
+	}
+}
+
+func updateEmoteSize(path string, size string) string {
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segments) == 0 {
+		return size
+	}
+
+	lastIndex := len(segments) - 1
+	if lastIndex >= 0 && (segments[lastIndex] == "1.0" || segments[lastIndex] == "2.0" || segments[lastIndex] == "3.0") {
+		segments[lastIndex] = size
+	} else {
+		segments = append(segments, size)
+	}
+
+	return "/" + strings.Join(segments, "/")
 }

--- a/internal/mapper/goquery_test.go
+++ b/internal/mapper/goquery_test.go
@@ -1,0 +1,23 @@
+package mapper
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoQueryHtmlEmoteMapperUsesRequestedSize(t *testing.T) {
+	html := `<div><div><img src="https://static-cdn.jtvnw.net/emoticons/v2/test/default/dark/3.0" /></div><samp>test</samp></div>`
+
+	m := NewGoQueryHtmlEmoteMapper()
+	emotes, err := m.ToEmotes(io.NopCloser(strings.NewReader(html)), "2.0")
+
+	assert.NoError(t, err)
+	assert.Len(t, emotes, 1)
+	href := emotes[0].Href()
+	assert.Contains(t, href.String(), "/default/")
+	assert.Contains(t, href.String(), "/2.0")
+	assert.NotContains(t, href.String(), "/3.0")
+}

--- a/pkg/adapter/controller/download_emotes.go
+++ b/pkg/adapter/controller/download_emotes.go
@@ -29,12 +29,14 @@ func NewDownloadEmotesController(
 func (c DownloadEmotesController) Handle(
 	hrefs []string,
 	output string,
+	size string,
 ) error {
 
 	channel :=
 		c.startDownloadImages(
 			c.startDownloadEmotes(
 				c.startParseHrefs(hrefs),
+				size,
 			),
 		)
 
@@ -61,13 +63,13 @@ func (c DownloadEmotesController) startParseHrefs(hrefs []string) <-chan url.URL
 	return out
 }
 
-func (c DownloadEmotesController) startDownloadEmotes(channel <-chan url.URL) <-chan []entity.Emote {
+func (c DownloadEmotesController) startDownloadEmotes(channel <-chan url.URL, size string) <-chan []entity.Emote {
 	out := make(chan []entity.Emote)
 
 	go func() {
 		defer close(out)
 		for u := range channel {
-			if emotes, err := c.downloadEmotesUseCase.Execute(u); err == nil {
+			if emotes, err := c.downloadEmotesUseCase.Execute(u, size); err == nil {
 				out <- emotes
 			}
 		}

--- a/pkg/application/usecase/download_emotes.go
+++ b/pkg/application/usecase/download_emotes.go
@@ -23,12 +23,12 @@ func NewDownloadEmotesUseCase(
 	}
 }
 
-func (u DownloadEmotesUseCase) Execute(url url.URL) ([]entity.Emote, error) {
+func (u DownloadEmotesUseCase) Execute(url url.URL, size string) ([]entity.Emote, error) {
 	res, err := u.download(url)
 	if err != nil {
 		return []entity.Emote{}, err
 	}
 	defer res.Body.Close()
 
-	return u.htmlEmoteMapper.ToEmotes(res.Body)
+	return u.htmlEmoteMapper.ToEmotes(res.Body, size)
 }

--- a/pkg/application/usecase/download_emotes_test.go
+++ b/pkg/application/usecase/download_emotes_test.go
@@ -13,7 +13,7 @@ func TestDownloadEmotesUseCaseWithFailedDownload(t *testing.T) {
 
 	usecase := NewDownloadEmotesUseCase(fakeDownloader.download, fakeMapper)
 
-	actual, err := usecase.Execute(url.URL{})
+	actual, err := usecase.Execute(url.URL{}, "3.0")
 
 	assert.Error(t, err)
 	assert.Empty(t, actual)
@@ -25,7 +25,7 @@ func TestDownloadEmotesUseCaseWithFailedMapper(t *testing.T) {
 
 	usecase := NewDownloadEmotesUseCase(fakeDownloader.download, fakeMapper)
 
-	actual, err := usecase.Execute(url.URL{})
+	actual, err := usecase.Execute(url.URL{}, "3.0")
 
 	assert.Error(t, err)
 	assert.Empty(t, actual)
@@ -37,7 +37,7 @@ func TestDownloadEmotesUseCase(t *testing.T) {
 
 	usecase := NewDownloadEmotesUseCase(fakeDownloader.download, fakeMapper)
 
-	actual, err := usecase.Execute(url.URL{})
+	actual, err := usecase.Execute(url.URL{}, "3.0")
 
 	assert.Nil(t, err)
 	assert.Empty(t, actual)

--- a/pkg/application/usecase/utils_test.go
+++ b/pkg/application/usecase/utils_test.go
@@ -40,7 +40,7 @@ type fakeMapper struct {
 	shouldError bool
 }
 
-func (m fakeMapper) ToEmotes(body io.ReadCloser) ([]entity.Emote, error) {
+func (m fakeMapper) ToEmotes(body io.ReadCloser, size string) ([]entity.Emote, error) {
 	if m.shouldError {
 		return []entity.Emote{}, errors.New("some error occurred")
 	}

--- a/pkg/domain/mapper/html_emote.go
+++ b/pkg/domain/mapper/html_emote.go
@@ -7,5 +7,5 @@ import (
 )
 
 type HtmlEmoteMapper interface {
-	ToEmotes(html io.ReadCloser) ([]entity.Emote, error)
+	ToEmotes(html io.ReadCloser, size string) ([]entity.Emote, error)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,7 +31,7 @@ func TestDownloadEmotesController(t *testing.T) {
 	hrefs := []string{"https://www.twitchmetrics.net/emotes"}
 	output := "output.zip"
 
-	err := c.Handle(hrefs, output)
+	err := c.Handle(hrefs, output, "3.0")
 
 	assert.Nil(t, err)
 


### PR DESCRIPTION
Add CLI flag (-s/--size) with validation to choose emote size (1.0 (28px), 2.0 (56px), or 3.0 (112px, default)). Propagate the size through controller, usecase and HtmlEmoteMapper interfaces. Update GoQuery mapper to normalize size and rewrite emote URL path segment to the requested size. Add unit test for the mapper and update existing tests and e2e to pass the size parameter. Also update README to mention `go mod download` and the correct `go run ./cmd/cli/main.go` invocation.